### PR TITLE
Mat 3267

### DIFF
--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/AdverseEventConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/AdverseEventConverter.java
@@ -1,6 +1,7 @@
 package gov.cms.mat.patients.conversion.conversion;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -52,6 +53,7 @@ public class AdverseEventConverter extends ConverterBase<AdverseEvent> {
         }
 
         if (qdmDataElement.getRelevantDatetime() != null) {
+            qdmDataElement.getRelevantDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             adverseEvent.setDateElement(qdmDataElement.getRelevantDatetime());
         }
 
@@ -62,6 +64,7 @@ public class AdverseEventConverter extends ConverterBase<AdverseEvent> {
         }
 
         if (qdmDataElement.getAuthorDatetime() != null) {
+            qdmDataElement.getAuthorDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             adverseEvent.setRecordedDateElement(qdmDataElement.getAuthorDatetime());
             log.info(UNEXPECTED_DATA_LOG_MESSAGE, QDM_TYPE, "authorDatetime");
         }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/AdverseEventConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/AdverseEventConverter.java
@@ -52,7 +52,7 @@ public class AdverseEventConverter extends ConverterBase<AdverseEvent> {
         }
 
         if (qdmDataElement.getRelevantDatetime() != null) {
-            adverseEvent.setDate(qdmDataElement.getRelevantDatetime());
+            adverseEvent.setDateElement(qdmDataElement.getRelevantDatetime());
         }
 
         if (CollectionUtils.isNotEmpty(qdmDataElement.getFacilityLocations())) {
@@ -62,7 +62,7 @@ public class AdverseEventConverter extends ConverterBase<AdverseEvent> {
         }
 
         if (qdmDataElement.getAuthorDatetime() != null) {
-            adverseEvent.setRecordedDate(qdmDataElement.getAuthorDatetime());
+            adverseEvent.setRecordedDateElement(qdmDataElement.getAuthorDatetime());
             log.info(UNEXPECTED_DATA_LOG_MESSAGE, QDM_TYPE, "authorDatetime");
         }
 

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/AllergyIntoleranceConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/AllergyIntoleranceConverter.java
@@ -9,7 +9,6 @@ import gov.cms.mat.patients.conversion.service.ValidationService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hl7.fhir.r4.model.AllergyIntolerance;
-import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Patient;
 import org.springframework.stereotype.Component;
 
@@ -48,15 +47,16 @@ public class AllergyIntoleranceConverter extends ConverterBase<AllergyIntoleranc
 
         if (qdmDataElement.getPrevalencePeriod() != null) {
             if (qdmDataElement.getPrevalencePeriod().getLow() != null) {
-                allergyIntolerance.setOnset(new DateTimeType(qdmDataElement.getPrevalencePeriod().getLow()));
+                allergyIntolerance.setOnset(qdmDataElement.getPrevalencePeriod().getLow());
             }
 
             if (qdmDataElement.getPrevalencePeriod().getHigh() != null) {
-                allergyIntolerance.setLastOccurrence(qdmDataElement.getPrevalencePeriod().getHigh());
+                allergyIntolerance.setLastOccurrenceElement(qdmDataElement.getPrevalencePeriod().getHigh());
             }
         }
 
-        allergyIntolerance.setRecordedDate(qdmDataElement.getAuthorDatetime());
+        if (qdmDataElement.getAuthorDatetime() != null)
+            allergyIntolerance.setRecordedDateElement(qdmDataElement.getAuthorDatetime());
 
         if (qdmDataElement.getType() != null) {
             conversionMessages.add("Cannot convert Allergy/Intolerance.type due to AllergyIntolerance.reaction tuple.");

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/AllergyIntoleranceConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/AllergyIntoleranceConverter.java
@@ -1,6 +1,7 @@
 package gov.cms.mat.patients.conversion.conversion;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -47,16 +48,21 @@ public class AllergyIntoleranceConverter extends ConverterBase<AllergyIntoleranc
 
         if (qdmDataElement.getPrevalencePeriod() != null) {
             if (qdmDataElement.getPrevalencePeriod().getLow() != null) {
+                qdmDataElement.getPrevalencePeriod().getLow().setPrecision(TemporalPrecisionEnum.MILLI);
                 allergyIntolerance.setOnset(qdmDataElement.getPrevalencePeriod().getLow());
             }
 
             if (qdmDataElement.getPrevalencePeriod().getHigh() != null) {
+                qdmDataElement.getPrevalencePeriod().getHigh().setPrecision(TemporalPrecisionEnum.MILLI);
                 allergyIntolerance.setLastOccurrenceElement(qdmDataElement.getPrevalencePeriod().getHigh());
             }
         }
 
-        if (qdmDataElement.getAuthorDatetime() != null)
+        if (qdmDataElement.getAuthorDatetime() != null) {
+            qdmDataElement.getAuthorDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             allergyIntolerance.setRecordedDateElement(qdmDataElement.getAuthorDatetime());
+        }
+
 
         if (qdmDataElement.getType() != null) {
             conversionMessages.add("Cannot convert Allergy/Intolerance.type due to AllergyIntolerance.reaction tuple.");

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/CareCoalConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/CareCoalConverter.java
@@ -14,14 +14,7 @@ import gov.cms.mat.patients.conversion.service.CodeSystemEntriesService;
 import gov.cms.mat.patients.conversion.service.ValidationService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.hl7.fhir.r4.model.DateType;
-import org.hl7.fhir.r4.model.Goal;
-import org.hl7.fhir.r4.model.IntegerType;
-import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Quantity;
-import org.hl7.fhir.r4.model.Ratio;
-import org.hl7.fhir.r4.model.StringType;
-import org.hl7.fhir.r4.model.Type;
+import org.hl7.fhir.r4.model.*;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -67,8 +60,8 @@ public class CareCoalConverter extends ConverterBase<Goal> {
         }
 
         if (qdmDataElement.getRelevantPeriod() != null) {
-            goal.setStart(new DateType(qdmDataElement.getRelevantPeriod().getLow()));
-            goal.getTargetFirstRep().setDue(new DateType(qdmDataElement.getRelevantPeriod().getHigh()));
+            goal.setStart(new DateType(qdmDataElement.getRelevantPeriod().getLow().toCalendar()) );
+            goal.getTargetFirstRep().setDue(new DateType(qdmDataElement.getRelevantPeriod().getHigh().toCalendar()));
         }
 
         if (qdmDataElement.getStatusDate() != null) {

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/CareCoalConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/CareCoalConverter.java
@@ -58,11 +58,12 @@ public class CareCoalConverter extends ConverterBase<Goal> {
             }
 
         }
-
-        if (qdmDataElement.getRelevantPeriod() != null) {
-            goal.setStart(new DateType(qdmDataElement.getRelevantPeriod().getLow().toCalendar()) );
-            goal.getTargetFirstRep().setDue(new DateType(qdmDataElement.getRelevantPeriod().getHigh().toCalendar()));
-        }
+        // Need to accept RelevantPeriod (DateTimeType) and convert to a DateTime type which doesn't accept time
+        // Need to consider TimeZone when converting to just Date.
+//        if (qdmDataElement.getRelevantPeriod() != null) {
+//            goal.setStart(new DateType(qdmDataElement.getRelevantPeriod().getLow()));
+//            goal.getTargetFirstRep().setDue(new DateType(String.valueOf(qdmDataElement.getRelevantPeriod().getHigh())));
+//        }
 
         if (qdmDataElement.getStatusDate() != null) {
             goal.setStatusDate(qdmDataElement.getStatusDate());

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/CareGoalConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/CareGoalConverter.java
@@ -22,10 +22,10 @@ import java.util.List;
 
 @Component
 @Slf4j
-public class CareCoalConverter extends ConverterBase<Goal> {
+public class CareGoalConverter extends ConverterBase<Goal> {
     public static final String QDM_TYPE = "QDM::CareGoal";
 
-    public CareCoalConverter(CodeSystemEntriesService codeSystemEntriesService,
+    public CareGoalConverter(CodeSystemEntriesService codeSystemEntriesService,
                              FhirContext fhirContext,
                              ObjectMapper objectMapper,
                              ValidationService validationService) {

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/CommunicationPerformedConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/CommunicationPerformedConverter.java
@@ -2,6 +2,7 @@ package gov.cms.mat.patients.conversion.conversion;
 
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.mat.patients.conversion.conversion.helpers.FhirCreator;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
@@ -54,10 +55,12 @@ public class CommunicationPerformedConverter extends ConverterBase<Communication
         }
 
         if (qdmDataElement.getSentDatetime() != null) {
+            qdmDataElement.getSentDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             communication.setSentElement(qdmDataElement.getSentDatetime());
         }
 
         if (qdmDataElement.getReceivedDatetime() != null) {
+            qdmDataElement.getReceivedDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             communication.setReceivedElement(qdmDataElement.getReceivedDatetime());
         }
 

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/CommunicationPerformedConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/CommunicationPerformedConverter.java
@@ -54,11 +54,11 @@ public class CommunicationPerformedConverter extends ConverterBase<Communication
         }
 
         if (qdmDataElement.getSentDatetime() != null) {
-            communication.setSent(qdmDataElement.getSentDatetime());
+            communication.setSentElement(qdmDataElement.getSentDatetime());
         }
 
         if (qdmDataElement.getReceivedDatetime() != null) {
-            communication.setReceived(qdmDataElement.getReceivedDatetime());
+            communication.setReceivedElement(qdmDataElement.getReceivedDatetime());
         }
 
         if (CollectionUtils.isNotEmpty(qdmDataElement.getRelatedTo())) {

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/DiagnosisConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/DiagnosisConverter.java
@@ -2,6 +2,7 @@ package gov.cms.mat.patients.conversion.conversion;
 
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -48,10 +49,12 @@ public class DiagnosisConverter extends ConverterBase<Condition> {
 
         if (qdmDataElement.getPrevalencePeriod() != null) {
             if (qdmDataElement.getPrevalencePeriod().getLow() != null) {
+                qdmDataElement.getPrevalencePeriod().getLow().setPrecision(TemporalPrecisionEnum.MILLI);
                 condition.setOnset(qdmDataElement.getPrevalencePeriod().getLow());
             }
 
             if (qdmDataElement.getPrevalencePeriod().getHigh() != null) {
+                qdmDataElement.getPrevalencePeriod().getHigh().setPrecision(TemporalPrecisionEnum.MILLI);
                 condition.setAbatement(qdmDataElement.getPrevalencePeriod().getHigh());
             }
         }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/DiagnosisConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/DiagnosisConverter.java
@@ -10,7 +10,6 @@ import gov.cms.mat.patients.conversion.service.ValidationService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hl7.fhir.r4.model.Condition;
-import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Patient;
 import org.springframework.stereotype.Component;
 
@@ -49,15 +48,15 @@ public class DiagnosisConverter extends ConverterBase<Condition> {
 
         if (qdmDataElement.getPrevalencePeriod() != null) {
             if (qdmDataElement.getPrevalencePeriod().getLow() != null) {
-                condition.setOnset(new DateTimeType(qdmDataElement.getPrevalencePeriod().getLow()));
+                condition.setOnset(qdmDataElement.getPrevalencePeriod().getLow());
             }
 
             if (qdmDataElement.getPrevalencePeriod().getHigh() != null) {
-                condition.setAbatement(new DateTimeType(qdmDataElement.getPrevalencePeriod().getHigh()));
+                condition.setAbatement(qdmDataElement.getPrevalencePeriod().getHigh());
             }
         }
 
-        condition.setRecordedDate(qdmDataElement.getAuthorDatetime()); // usually comes in as null
+        condition.setRecordedDateElement(qdmDataElement.getAuthorDatetime()); // usually comes in as null
 
         if (qdmDataElement.getSeverity() != null) {
             condition.setSeverity(convertToCodeableConcept(qdmDataElement.getSeverity()));

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/DiagnosisConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/DiagnosisConverter.java
@@ -59,7 +59,10 @@ public class DiagnosisConverter extends ConverterBase<Condition> {
             }
         }
 
-        condition.setRecordedDateElement(qdmDataElement.getAuthorDatetime()); // usually comes in as null
+        if (qdmDataElement.getAuthorDatetime() != null) {
+            qdmDataElement.getAuthorDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
+            condition.setRecordedDateElement(qdmDataElement.getAuthorDatetime()); // usually comes in as null
+        }
 
         if (qdmDataElement.getSeverity() != null) {
             condition.setSeverity(convertToCodeableConcept(qdmDataElement.getSeverity()));

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/FamilyHistoryConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/FamilyHistoryConverter.java
@@ -1,6 +1,7 @@
 package gov.cms.mat.patients.conversion.conversion;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -46,7 +47,10 @@ public class FamilyHistoryConverter extends ConverterBase<FamilyMemberHistory> {
 
         familyMemberHistory.setId(qdmDataElement.getId());
 
-        familyMemberHistory.setDateElement(qdmDataElement.getAuthorDatetime());
+        if (qdmDataElement.getAuthorDatetime() != null) {
+            qdmDataElement.getAuthorDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
+            familyMemberHistory.setDateElement(qdmDataElement.getAuthorDatetime());
+        }
 
         familyMemberHistory.setStatus(FamilyMemberHistory.FamilyHistoryStatus.COMPLETED);
 

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/FamilyHistoryConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/FamilyHistoryConverter.java
@@ -46,7 +46,7 @@ public class FamilyHistoryConverter extends ConverterBase<FamilyMemberHistory> {
 
         familyMemberHistory.setId(qdmDataElement.getId());
 
-        familyMemberHistory.setDate(qdmDataElement.getAuthorDatetime());
+        familyMemberHistory.setDateElement(qdmDataElement.getAuthorDatetime());
 
         familyMemberHistory.setStatus(FamilyMemberHistory.FamilyHistoryStatus.COMPLETED);
 

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/ImmunizationAdministeredConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/ImmunizationAdministeredConverter.java
@@ -8,7 +8,6 @@ import gov.cms.mat.patients.conversion.service.CodeSystemEntriesService;
 import gov.cms.mat.patients.conversion.service.ValidationService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Immunization;
 import org.hl7.fhir.r4.model.Patient;
 import org.springframework.stereotype.Component;
@@ -72,10 +71,10 @@ public class ImmunizationAdministeredConverter extends ConverterBase<Immunizatio
         }
 
         if (qdmDataElement.getRelevantDatetime() != null) {
-            immunization.setOccurrence(new DateTimeType(qdmDataElement.getRelevantDatetime()));
+            immunization.setOccurrence(qdmDataElement.getRelevantDatetime());
         }
 
-        immunization.setRecorded(qdmDataElement.getAuthorDatetime());
+        immunization.setRecordedElement(qdmDataElement.getAuthorDatetime());
 
         if (qdmDataElement.getPerformer() != null) {
             log.info(UNEXPECTED_DATA_LOG_MESSAGE, QDM_TYPE, "performer");

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/ImmunizationAdministeredConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/ImmunizationAdministeredConverter.java
@@ -1,6 +1,7 @@
 package gov.cms.mat.patients.conversion.conversion;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -71,10 +72,15 @@ public class ImmunizationAdministeredConverter extends ConverterBase<Immunizatio
         }
 
         if (qdmDataElement.getRelevantDatetime() != null) {
+            qdmDataElement.getRelevantDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             immunization.setOccurrence(qdmDataElement.getRelevantDatetime());
         }
 
-        immunization.setRecordedElement(qdmDataElement.getAuthorDatetime());
+        if (qdmDataElement.getAuthorDatetime() != null) {
+            qdmDataElement.getAuthorDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
+            immunization.setRecordedElement(qdmDataElement.getAuthorDatetime());
+        }
+
 
         if (qdmDataElement.getPerformer() != null) {
             log.info(UNEXPECTED_DATA_LOG_MESSAGE, QDM_TYPE, "performer");

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/MedicationAdministeredConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/MedicationAdministeredConverter.java
@@ -8,7 +8,6 @@ import gov.cms.mat.patients.conversion.service.CodeSystemEntriesService;
 import gov.cms.mat.patients.conversion.service.ValidationService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.MedicationAdministration;
 import org.hl7.fhir.r4.model.Patient;
 import org.springframework.stereotype.Component;
@@ -70,7 +69,7 @@ public class MedicationAdministeredConverter extends ConverterBase<MedicationAdm
         }
 
         if (!havePeriod && qdmDataElement.getRelevantDatetime() != null) {
-            medicationAdministration.setEffective(new DateTimeType(qdmDataElement.getRelevantDatetime()));
+            medicationAdministration.setEffective(qdmDataElement.getRelevantDatetime());
         }
 
         if (qdmDataElement.getPerformer() != null) {

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/MedicationAdministeredConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/MedicationAdministeredConverter.java
@@ -1,6 +1,7 @@
 package gov.cms.mat.patients.conversion.conversion;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -69,6 +70,7 @@ public class MedicationAdministeredConverter extends ConverterBase<MedicationAdm
         }
 
         if (!havePeriod && qdmDataElement.getRelevantDatetime() != null) {
+            qdmDataElement.getRelevantDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             medicationAdministration.setEffective(qdmDataElement.getRelevantDatetime());
         }
 

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/MedicationDispensedConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/MedicationDispensedConverter.java
@@ -101,7 +101,7 @@ public class MedicationDispensedConverter extends ConverterBase<MedicationDispen
 
     private void processTimes(QdmDataElement qdmDataElement, MedicationDispense medicationDispense) {
         if (qdmDataElement.getRelevantDatetime() != null) {
-            medicationDispense.setWhenHandedOver(qdmDataElement.getRelevantDatetime());
+            medicationDispense.setWhenHandedOverElement(qdmDataElement.getRelevantDatetime());
         }
 
         if (qdmDataElement.getRelevantPeriod() != null) {

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/MedicationDispensedConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/MedicationDispensedConverter.java
@@ -2,6 +2,7 @@ package gov.cms.mat.patients.conversion.conversion;
 
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -101,6 +102,7 @@ public class MedicationDispensedConverter extends ConverterBase<MedicationDispen
 
     private void processTimes(QdmDataElement qdmDataElement, MedicationDispense medicationDispense) {
         if (qdmDataElement.getRelevantDatetime() != null) {
+            qdmDataElement.getRelevantDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             medicationDispense.setWhenHandedOverElement(qdmDataElement.getRelevantDatetime());
         }
 

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/ParticipationConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/ParticipationConverter.java
@@ -1,6 +1,7 @@
 package gov.cms.mat.patients.conversion.conversion;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -60,6 +61,8 @@ public class ParticipationConverter extends ConverterBase<Coverage> {
 
     private void convertParticipationPeriod(Coverage coverage, QdmDataElement qdmDataElement) {
         QdmPeriod qdmInterval = qdmDataElement.getParticipationPeriod();
+        qdmInterval.getLow().setPrecision(TemporalPrecisionEnum.MILLI);
+        qdmInterval.getHigh().setPrecision(TemporalPrecisionEnum.MILLI);
         coverage.getPeriod().setStartElement(qdmInterval.getLow());
         coverage.getPeriod().setEndElement(qdmInterval.getHigh());
     }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/ParticipationConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/ParticipationConverter.java
@@ -60,7 +60,7 @@ public class ParticipationConverter extends ConverterBase<Coverage> {
 
     private void convertParticipationPeriod(Coverage coverage, QdmDataElement qdmDataElement) {
         QdmPeriod qdmInterval = qdmDataElement.getParticipationPeriod();
-        coverage.getPeriod().setStart(qdmInterval.getLow());
-        coverage.getPeriod().setEnd(qdmInterval.getHigh());
+        coverage.getPeriod().setStartElement(qdmInterval.getLow());
+        coverage.getPeriod().setEndElement(qdmInterval.getHigh());
     }
 }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/ParticipationConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/ParticipationConverter.java
@@ -61,8 +61,12 @@ public class ParticipationConverter extends ConverterBase<Coverage> {
 
     private void convertParticipationPeriod(Coverage coverage, QdmDataElement qdmDataElement) {
         QdmPeriod qdmInterval = qdmDataElement.getParticipationPeriod();
-        qdmInterval.getLow().setPrecision(TemporalPrecisionEnum.MILLI);
-        qdmInterval.getHigh().setPrecision(TemporalPrecisionEnum.MILLI);
+
+        if (qdmInterval.getLow() != null)
+            qdmInterval.getLow().setPrecision(TemporalPrecisionEnum.MILLI);
+        if (qdmInterval.getHigh() != null)
+            qdmInterval.getHigh().setPrecision(TemporalPrecisionEnum.MILLI);
+
         coverage.getPeriod().setStartElement(qdmInterval.getLow());
         coverage.getPeriod().setEndElement(qdmInterval.getHigh());
     }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientCharacteristicPayerConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientCharacteristicPayerConverter.java
@@ -58,10 +58,12 @@ public class PatientCharacteristicPayerConverter extends ConverterBase<Coverage>
 
     private void convertRelevantPeriod(Coverage coverage, QdmDataElement qdmDataElement) {
         var qdmPeriod = qdmDataElement.getRelevantPeriod();
+
         if (qdmPeriod.getLow() != null)
             qdmPeriod.getLow().setPrecision(TemporalPrecisionEnum.MILLI);
         if (qdmPeriod.getHigh() != null)
             qdmPeriod.getHigh().setPrecision(TemporalPrecisionEnum.MILLI);
+
         coverage.getPeriod().setStartElement(qdmPeriod.getLow());
         coverage.getPeriod().setEndElement(qdmPeriod.getHigh());
     }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientCharacteristicPayerConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientCharacteristicPayerConverter.java
@@ -57,7 +57,7 @@ public class PatientCharacteristicPayerConverter extends ConverterBase<Coverage>
 
     private void convertRelevantPeriod(Coverage coverage, QdmDataElement qdmDataElement) {
         var qdmPeriod = qdmDataElement.getRelevantPeriod();
-        coverage.getPeriod().setStart(qdmPeriod.getLow());
-        coverage.getPeriod().setEnd(qdmPeriod.getHigh());
+        coverage.getPeriod().setStartElement(qdmPeriod.getLow());
+        coverage.getPeriod().setEndElement(qdmPeriod.getHigh());
     }
 }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientCharacteristicPayerConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientCharacteristicPayerConverter.java
@@ -1,6 +1,7 @@
 package gov.cms.mat.patients.conversion.conversion;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -57,6 +58,10 @@ public class PatientCharacteristicPayerConverter extends ConverterBase<Coverage>
 
     private void convertRelevantPeriod(Coverage coverage, QdmDataElement qdmDataElement) {
         var qdmPeriod = qdmDataElement.getRelevantPeriod();
+        if (qdmPeriod.getLow() != null)
+            qdmPeriod.getLow().setPrecision(TemporalPrecisionEnum.MILLI);
+        if (qdmPeriod.getHigh() != null)
+            qdmPeriod.getHigh().setPrecision(TemporalPrecisionEnum.MILLI);
         coverage.getPeriod().setStartElement(qdmPeriod.getLow());
         coverage.getPeriod().setEndElement(qdmPeriod.getHigh());
     }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientConverter.java
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientConverter.java
@@ -1,5 +1,6 @@
 package gov.cms.mat.patients.conversion.conversion;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import gov.cms.mat.patients.conversion.conversion.helpers.DataElementFinder;
 import gov.cms.mat.patients.conversion.conversion.helpers.FhirCreator;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirPatientResult;
@@ -134,6 +135,8 @@ public class PatientConverter implements DataElementFinder, FhirCreator {
         if (optional.isPresent()) {
             QdmDataElement dataElement = optional.get();
             log.trace("Patient is dead");
+            if (dataElement.getExpiredDatetime() != null)
+                dataElement.getExpiredDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             return dataElement.getExpiredDatetime();
         } else {
             log.trace("Patient is alive");

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/PatientConverter.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -133,7 +134,7 @@ public class PatientConverter implements DataElementFinder, FhirCreator {
         if (optional.isPresent()) {
             QdmDataElement dataElement = optional.get();
             log.trace("Patient is dead");
-            return new DateTimeType(dataElement.getExpiredDatetime());
+            return dataElement.getExpiredDatetime();
         } else {
             log.trace("Patient is alive");
             return null;

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/FhirCreator.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/FhirCreator.java
@@ -122,7 +122,7 @@ public interface FhirCreator {
     }
 
     default Extension createRecordedExtension(DateTimeType date) {
-        date.setPrecision(TemporalPrecisionEnum.MILLI);
+        if (date != null) date.setPrecision(TemporalPrecisionEnum.MILLI);
         return new Extension(QICORE_RECORDED)
                 .setValue(date);
     }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/FhirCreator.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/FhirCreator.java
@@ -1,6 +1,7 @@
 package gov.cms.mat.patients.conversion.conversion.helpers;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import gov.cms.mat.patients.conversion.dao.conversion.BonniePatient;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmCodeSystem;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -70,6 +71,10 @@ public interface FhirCreator {
     }
 
     default Period convertPeriod(QdmPeriod relevantPeriod) {
+        if (relevantPeriod.getLow() != null)
+            relevantPeriod.getLow().setPrecision(TemporalPrecisionEnum.MILLI);
+        if (relevantPeriod.getHigh() != null)
+            relevantPeriod.getHigh().setPrecision(TemporalPrecisionEnum.MILLI);
         return new Period()
                 .setStartElement(relevantPeriod.getLow())
                 .setEndElement(relevantPeriod.getHigh());
@@ -117,6 +122,7 @@ public interface FhirCreator {
     }
 
     default Extension createRecordedExtension(DateTimeType date) {
+        date.setPrecision(TemporalPrecisionEnum.MILLI);
         return new Extension(QICORE_RECORDED)
                 .setValue(date);
     }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/FhirCreator.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/FhirCreator.java
@@ -23,7 +23,6 @@ import org.hl7.fhir.r4.model.StringType;
 import org.springframework.util.CollectionUtils;
 
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -72,8 +71,8 @@ public interface FhirCreator {
 
     default Period convertPeriod(QdmPeriod relevantPeriod) {
         return new Period()
-                .setStart(relevantPeriod.getLow())
-                .setEnd(relevantPeriod.getHigh() == null ? null : relevantPeriod.getHigh());
+                .setStartElement(relevantPeriod.getLow())
+                .setEndElement(relevantPeriod.getHigh());
     }
 
     default String toJson(FhirContext fhirContext, IBaseResource theResource) {
@@ -117,9 +116,9 @@ public interface FhirCreator {
                 .setValue(new BooleanType(true));
     }
 
-    default Extension createRecordedExtension(Date date) {
+    default Extension createRecordedExtension(DateTimeType date) {
         return new Extension(QICORE_RECORDED)
-                .setValue(new DateTimeType(date));
+                .setValue(date);
     }
 
     default Set<String> collectQdmTypes(BonniePatient bonniePatient) {

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/MedicationRequestConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/MedicationRequestConverter.java
@@ -1,5 +1,6 @@
 package gov.cms.mat.patients.conversion.conversion.helpers;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import gov.cms.mat.patients.conversion.conversion.ConverterBase;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmCodeSystem;
@@ -71,6 +72,7 @@ public interface MedicationRequestConverter extends FhirCreator, DataElementFind
 
         if (qdmDataElement.getRelevantDatetime() != null) {
             var dosage = medicationRequest.getDosageInstructionFirstRep();
+            qdmDataElement.getRelevantDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             List<DateTimeType> relevantDateTime = new ArrayList<>() {{
                 add(qdmDataElement.getRelevantDatetime());
             }};
@@ -86,14 +88,16 @@ public interface MedicationRequestConverter extends FhirCreator, DataElementFind
 
         if (qdmDataElement.getActiveDatetime() != null) {
             var dosage = medicationRequest.getDosageInstructionFirstRep();
-
+            qdmDataElement.getActiveDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             var period = new Period()
                     .setStartElement(qdmDataElement.getActiveDatetime());
             dosage.getTiming().getRepeat().setBounds(period);
         }
 
-        medicationRequest.setAuthoredOnElement(qdmDataElement.getAuthorDatetime());
-
+        if (qdmDataElement.getAuthorDatetime() != null) {
+            qdmDataElement.getAuthorDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
+            medicationRequest.setAuthoredOnElement(qdmDataElement.getAuthorDatetime());
+        }
 
         if (!converterBase.processNegation(qdmDataElement, medicationRequest) && setStatusToUnknown) {
             medicationRequest.setStatus(MedicationRequest.MedicationRequestStatus.COMPLETED);

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/MedicationRequestConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/MedicationRequestConverter.java
@@ -5,11 +5,7 @@ import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionRes
 import gov.cms.mat.patients.conversion.dao.conversion.QdmCodeSystem;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
 import org.apache.commons.collections4.CollectionUtils;
-import org.hl7.fhir.r4.model.CodeableConcept;
-import org.hl7.fhir.r4.model.Duration;
-import org.hl7.fhir.r4.model.MedicationRequest;
-import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +71,10 @@ public interface MedicationRequestConverter extends FhirCreator, DataElementFind
 
         if (qdmDataElement.getRelevantDatetime() != null) {
             var dosage = medicationRequest.getDosageInstructionFirstRep();
-            dosage.getTiming().addEvent(qdmDataElement.getRelevantDatetime());
+            List<DateTimeType> relevantDateTime = new ArrayList<>() {{
+                add(qdmDataElement.getRelevantDatetime());
+            }};
+            dosage.getTiming().setEvent(relevantDateTime);
         }
 
         if (qdmDataElement.getRelevantPeriod() != null) {
@@ -88,12 +87,12 @@ public interface MedicationRequestConverter extends FhirCreator, DataElementFind
         if (qdmDataElement.getActiveDatetime() != null) {
             var dosage = medicationRequest.getDosageInstructionFirstRep();
 
-            var period = new Period();
-            period.setStart(qdmDataElement.getActiveDatetime());
+            var period = new Period()
+                    .setStartElement(qdmDataElement.getActiveDatetime());
             dosage.getTiming().getRepeat().setBounds(period);
         }
 
-        medicationRequest.setAuthoredOn(qdmDataElement.getAuthorDatetime());
+        medicationRequest.setAuthoredOnElement(qdmDataElement.getAuthorDatetime());
 
 
         if (!converterBase.processNegation(qdmDataElement, medicationRequest) && setStatusToUnknown) {

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ObservationConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ObservationConverter.java
@@ -1,5 +1,6 @@
 package gov.cms.mat.patients.conversion.conversion.helpers;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import gov.cms.mat.patients.conversion.conversion.ConverterBase;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmCodeSystem;
@@ -41,6 +42,7 @@ public interface ObservationConverter extends FhirCreator, DataElementFinder {
         }
 
         if (!observation.hasEffectivePeriod() && qdmDataElement.getRelevantDatetime() != null) {
+            qdmDataElement.getRelevantDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             observation.setEffective(qdmDataElement.getRelevantDatetime());
         }
 
@@ -49,8 +51,10 @@ public interface ObservationConverter extends FhirCreator, DataElementFinder {
         }
 
         if (qdmDataElement.getAuthorDatetime() != null) {
+            qdmDataElement.getAuthorDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             observation.setIssuedElement(new InstantType(qdmDataElement.getAuthorDatetime()));
         } else if (qdmDataElement.getResultDatetime() != null) {
+            qdmDataElement.getResultDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             observation.setIssuedElement(new InstantType(qdmDataElement.getResultDatetime()));
         }
 

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ObservationConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ObservationConverter.java
@@ -7,7 +7,7 @@ import gov.cms.mat.patients.conversion.dao.conversion.QdmComponent;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
 import gov.cms.mat.patients.conversion.service.CodeSystemEntriesService;
 import org.apache.commons.collections4.CollectionUtils;
-import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 
@@ -41,7 +41,7 @@ public interface ObservationConverter extends FhirCreator, DataElementFinder {
         }
 
         if (!observation.hasEffectivePeriod() && qdmDataElement.getRelevantDatetime() != null) {
-            observation.setEffective(new DateTimeType(qdmDataElement.getRelevantDatetime()));
+            observation.setEffective(qdmDataElement.getRelevantDatetime());
         }
 
         if (!converterBase.processNegation(qdmDataElement, observation)) {
@@ -49,9 +49,9 @@ public interface ObservationConverter extends FhirCreator, DataElementFinder {
         }
 
         if (qdmDataElement.getAuthorDatetime() != null) {
-            observation.setIssued(qdmDataElement.getAuthorDatetime());
-        } else {
-            observation.setIssued(qdmDataElement.getResultDatetime());
+            observation.setIssuedElement(new InstantType(qdmDataElement.getAuthorDatetime()));
+        } else if (qdmDataElement.getResultDatetime() != null) {
+            observation.setIssuedElement(new InstantType(qdmDataElement.getResultDatetime()));
         }
 
         if (CollectionUtils.isNotEmpty(qdmDataElement.getComponents())) {

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ProcedureConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ProcedureConverter.java
@@ -1,5 +1,6 @@
 package gov.cms.mat.patients.conversion.conversion.helpers;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import gov.cms.mat.patients.conversion.conversion.ConverterBase;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -66,6 +67,7 @@ public interface ProcedureConverter extends DataElementFinder, FhirCreator {
         }
 
         if (!havePeriod && qdmDataElement.getRelevantDatetime() != null) {
+            qdmDataElement.getRelevantDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             procedure.setPerformed(qdmDataElement.getRelevantDatetime());
         }
 
@@ -73,6 +75,7 @@ public interface ProcedureConverter extends DataElementFinder, FhirCreator {
             procedure.getExtension()
                     .add(new Extension(INCISION_DATE_TIME_URL));
             var extension = procedure.getExtension().get(0);
+            qdmDataElement.getIncisionDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
             extension.setValue(qdmDataElement.getIncisionDatetime());
         }
 

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ProcedureConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ProcedureConverter.java
@@ -4,7 +4,6 @@ import gov.cms.mat.patients.conversion.conversion.ConverterBase;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
 import org.apache.commons.collections4.CollectionUtils;
-import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Procedure;
@@ -67,14 +66,14 @@ public interface ProcedureConverter extends DataElementFinder, FhirCreator {
         }
 
         if (!havePeriod && qdmDataElement.getRelevantDatetime() != null) {
-            procedure.setPerformed(new DateTimeType(qdmDataElement.getRelevantDatetime()));
+            procedure.setPerformed(qdmDataElement.getRelevantDatetime());
         }
 
         if (qdmDataElement.getIncisionDatetime() != null) {
             procedure.getExtension()
                     .add(new Extension(INCISION_DATE_TIME_URL));
             var extension = procedure.getExtension().get(0);
-            extension.setValue(new DateTimeType(qdmDataElement.getIncisionDatetime()));
+            extension.setValue(qdmDataElement.getIncisionDatetime());
         }
 
         if (CollectionUtils.isNotEmpty(qdmDataElement.getComponents())) {

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ServiceRequestConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ServiceRequestConverter.java
@@ -1,5 +1,6 @@
 package gov.cms.mat.patients.conversion.conversion.helpers;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import gov.cms.mat.patients.conversion.conversion.ConverterBase;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -34,7 +35,10 @@ public interface ServiceRequestConverter extends DataElementFinder, FhirCreator 
             serviceRequest.getReasonCode().add(converterBase.convertToCodeableConcept(qdmDataElement.getReason()));
         }
 
-        serviceRequest.setAuthoredOnElement(qdmDataElement.getAuthorDatetime());
+        if (qdmDataElement.getAuthorDatetime() != null) {
+            qdmDataElement.getAuthorDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
+            serviceRequest.setAuthoredOnElement(qdmDataElement.getAuthorDatetime());
+        }
 
         if (!converterBase.processNegation(qdmDataElement, serviceRequest)) {
             serviceRequest.setStatus(ServiceRequest.ServiceRequestStatus.ACTIVE);

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ServiceRequestConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/ServiceRequestConverter.java
@@ -34,7 +34,7 @@ public interface ServiceRequestConverter extends DataElementFinder, FhirCreator 
             serviceRequest.getReasonCode().add(converterBase.convertToCodeableConcept(qdmDataElement.getReason()));
         }
 
-        serviceRequest.setAuthoredOn(qdmDataElement.getAuthorDatetime());
+        serviceRequest.setAuthoredOnElement(qdmDataElement.getAuthorDatetime());
 
         if (!converterBase.processNegation(qdmDataElement, serviceRequest)) {
             serviceRequest.setStatus(ServiceRequest.ServiceRequestStatus.ACTIVE);

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/SubstanceConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/SubstanceConverter.java
@@ -4,7 +4,6 @@ import gov.cms.mat.patients.conversion.conversion.ConverterBase;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
 import org.apache.commons.collections4.CollectionUtils;
-import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.NutritionOrder;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Timing;
@@ -39,7 +38,7 @@ public interface SubstanceConverter extends DataElementFinder, FhirCreator {
             converterBase.getLog().info(UNEXPECTED_DATA_LOG_MESSAGE, converterBase.getQdmType(), "frequency");
         }
 
-        nutritionOrder.setDateTime(qdmDataElement.getAuthorDatetime());
+        nutritionOrder.setDateTimeElement(qdmDataElement.getAuthorDatetime());
 
         if (qdmDataElement.getRoute() != null) {
             converterBase.getLog().info(UNEXPECTED_DATA_LOG_MESSAGE, converterBase.getQdmType(), "route");
@@ -58,7 +57,7 @@ public interface SubstanceConverter extends DataElementFinder, FhirCreator {
         if (qdmDataElement.getRelevantPeriod() != null) {
             var timing = new Timing();
 
-            timing.getEvent().add(new DateTimeType(qdmDataElement.getRelevantPeriod().getLow()));
+            timing.getEvent().add(qdmDataElement.getRelevantPeriod().getLow());
 
             nutritionOrder.getEnteralFormula().getAdministrationFirstRep().setSchedule(timing);
         }

--- a/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/SubstanceConverter.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/conversion/helpers/SubstanceConverter.java
@@ -1,5 +1,6 @@
 package gov.cms.mat.patients.conversion.conversion.helpers;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import gov.cms.mat.patients.conversion.conversion.ConverterBase;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
@@ -38,7 +39,10 @@ public interface SubstanceConverter extends DataElementFinder, FhirCreator {
             converterBase.getLog().info(UNEXPECTED_DATA_LOG_MESSAGE, converterBase.getQdmType(), "frequency");
         }
 
-        nutritionOrder.setDateTimeElement(qdmDataElement.getAuthorDatetime());
+        if (qdmDataElement.getAuthorDatetime() != null) {
+            qdmDataElement.getAuthorDatetime().setPrecision(TemporalPrecisionEnum.MILLI);
+            nutritionOrder.setDateTimeElement(qdmDataElement.getAuthorDatetime());
+        }
 
         if (qdmDataElement.getRoute() != null) {
             converterBase.getLog().info(UNEXPECTED_DATA_LOG_MESSAGE, converterBase.getQdmType(), "route");
@@ -56,9 +60,10 @@ public interface SubstanceConverter extends DataElementFinder, FhirCreator {
 
         if (qdmDataElement.getRelevantPeriod() != null) {
             var timing = new Timing();
-
-            timing.getEvent().add(qdmDataElement.getRelevantPeriod().getLow());
-
+            if (qdmDataElement.getRelevantPeriod().getLow() != null) {
+                qdmDataElement.getRelevantPeriod().getLow().setPrecision(TemporalPrecisionEnum.MILLI);
+                timing.getEvent().add(qdmDataElement.getRelevantPeriod().getLow());
+            }
             nutritionOrder.getEnteralFormula().getAdministrationFirstRep().setSchedule(timing);
         }
 

--- a/src/main/java/gov/cms/mat/patients/conversion/dao/conversion/QdmDataElement.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/dao/conversion/QdmDataElement.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hl7.fhir.r4.model.DateTimeType;
 
 import java.util.Date;
 import java.util.List;
@@ -39,11 +40,11 @@ public class QdmDataElement {
 
     private List<String> relatedTo;
 
-    private Date expiredDatetime;
-    private Date activeDatetime;
-    private Date birthDatetime;
+    private DateTimeType expiredDatetime;
+    private DateTimeType activeDatetime;
+    private DateTimeType birthDatetime;
 
-    private Date authorDatetime;
+    private DateTimeType authorDatetime;
 
     private Integer refills;
     private QdmQuantity dosage;
@@ -70,7 +71,7 @@ public class QdmDataElement {
     private QdmReferenceRange referenceRange;
 
     private QdmCodeSystem status;
-    private Date resultDatetime;
+    private DateTimeType resultDatetime;
     private QdmCodeSystem method;
 
     private QdmCodeSystem negationRationale;
@@ -84,7 +85,7 @@ public class QdmDataElement {
     private QdmCodeSystem severity;
     private QdmCodeSystem relationship;
 
-    private Date incisionDatetime;
+    private DateTimeType incisionDatetime;
 
     private List<QdmComponent> components;
 
@@ -94,14 +95,14 @@ public class QdmDataElement {
 
     private String codeListId;
 
-    private Date relevantDatetime;
+    private DateTimeType relevantDatetime;
 
     private String rank;
 
     private QdmCodeSystem category;
     private QdmCodeSystem medium;
-    private Date sentDatetime;
-    private Date receivedDatetime;
+    private DateTimeType sentDatetime;
+    private DateTimeType receivedDatetime;
 
     private QdmPractitioner sender;
     private QdmPractitioner recipient;

--- a/src/main/java/gov/cms/mat/patients/conversion/dao/conversion/QdmPeriod.java
+++ b/src/main/java/gov/cms/mat/patients/conversion/dao/conversion/QdmPeriod.java
@@ -3,14 +3,13 @@ package gov.cms.mat.patients.conversion.dao.conversion;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.Date;
+import org.hl7.fhir.r4.model.DateTimeType;
 
 @Data
 @NoArgsConstructor
 public class QdmPeriod {
-    private Date low;
-    private Date high;
+    private DateTimeType low;
+    private DateTimeType high;
     private Boolean lowClosed;
     private Boolean highClosed;
 

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/AdverseEventConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/AdverseEventConverterTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -31,19 +30,19 @@ class AdverseEventConverterTest extends BaseConversionTest implements FhirConver
     void convertToFhir() {
         qdmDataElement.setDataElementCodes(List.of(createDataElementCode()));
         qdmDataElement.setRelevantDatetime(createRelevantDatetime());
+        qdmDataElement.setAuthorDatetime(createAuthorDatetime());
 
         QdmToFhirConversionResult<AdverseEvent> result = adverseEventConverter.convertToFhir(fhirPatient, qdmDataElement);
 
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
         checkDataElementCodeableConcept(result.getFhirResource().getEvent());
-        checkRelevantDateTime(result.getFhirResource().getDate());
-
+        checkRelevantDateTime(result.getFhirResource().getDateElement());
+        checkAuthorDatetime(result.getFhirResource().getRecordedDateElement());
         /// ensure not mapped
         assertFalse(result.getFhirResource().hasCategory());
         assertFalse(result.getFhirResource().hasSeverity());
         assertFalse(result.getFhirResource().hasLocation());
-        assertNull(result.getFhirResource().getRecordedDate());
 
         assertEquals(AdverseEvent.AdverseEventActuality.ACTUAL, result.getFhirResource().getActuality());
     }
@@ -62,7 +61,6 @@ class AdverseEventConverterTest extends BaseConversionTest implements FhirConver
         qdmDataElement.setType(createType());
         qdmDataElement.setSeverity(createSeverity());
         qdmDataElement.setFacilityLocations(List.of(createFacilityLocation()));
-        qdmDataElement.setAuthorDatetime(createAuthorDatetime());
 
         QdmToFhirConversionResult<AdverseEvent> result = adverseEventConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/AllergyIntoleranceConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/AllergyIntoleranceConverterTest.java
@@ -39,11 +39,11 @@ class AllergyIntoleranceConverterTest extends BaseConversionTest implements Fhir
 
         checkDataElementCodeableConcept(result.getFhirResource().getCode());
 
-        QdmPeriod qdmPeriod = createPrevalencePeriod();
-        assertEquals(qdmPeriod.getLow(), result.getFhirResource().getOnsetDateTimeType().getValue());
-        assertEquals(qdmPeriod.getHigh(), result.getFhirResource().getLastOccurrence());
+        QdmPeriod qdmPeriod = qdmDataElement.getPrevalencePeriod();
+        assertEquals(qdmPeriod.getLow(), result.getFhirResource().getOnset());
+        assertEquals(qdmPeriod.getHigh(), result.getFhirResource().getLastOccurrenceElement());
 
-        checkAuthorDatetime(result.getFhirResource().getRecordedDate());
+        checkAuthorDatetime(result.getFhirResource().getRecordedDateElement());
 
         assertFalse(result.getFhirResource().getReactionFirstRep().hasSeverity()); // we cannot convert
 

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/CareCoalConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/CareCoalConverterTest.java
@@ -61,10 +61,10 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
 
         checkTargetOutCome(result.getFhirResource().getTargetFirstRep().getDetailCodeableConcept());
 
-        Type type = result.getFhirResource().getTargetFirstRep().getDue();
-        assertThat(type, instanceOf(DateType.class));
+        DateType dueDate = (DateType) result.getFhirResource().getTargetFirstRep().getDue();
+        assertThat(dueDate, instanceOf(DateType.class));
 
-        checkRelevantPeriodGoal(result.getFhirResource().getStart(), (DateType) type);
+        checkRelevantPeriodGoal((DateType) result.getFhirResource().getStart(), dueDate);
 
         checkRelatedTo(result.getFhirResource().getAddressesFirstRep());
         checkPerformer(result.getFhirResource().getExpressedBy());

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/CareCoalConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/CareCoalConverterTest.java
@@ -12,10 +12,8 @@ import gov.cms.mat.patients.conversion.dao.conversion.QdmQuantity;
 import gov.cms.mat.patients.conversion.dao.conversion.TargetOutcome;
 import lombok.Data;
 import lombok.SneakyThrows;
-import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.Goal;
 import org.hl7.fhir.r4.model.Ratio;
-import org.hl7.fhir.r4.model.Type;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,8 +21,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -61,10 +57,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
 
         checkTargetOutCome(result.getFhirResource().getTargetFirstRep().getDetailCodeableConcept());
 
-        DateType dueDate = (DateType) result.getFhirResource().getTargetFirstRep().getDue();
-        assertThat(dueDate, instanceOf(DateType.class));
-
-        checkRelevantPeriodGoal((DateType) result.getFhirResource().getStart(), dueDate);
+//        checkRelevantPeriodGoal(result.getFhirResource().getStartDateType(), result.getFhirResource().getTargetFirstRep().getDueDateType());
 
         checkRelatedTo(result.getFhirResource().getAddressesFirstRep());
         checkPerformer(result.getFhirResource().getExpressedBy());

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/CareGoalConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/CareGoalConverterTest.java
@@ -27,14 +27,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class CareCoalConverterTest extends BaseConversionTest implements FhirConversionTest {
+class CareGoalConverterTest extends BaseConversionTest implements FhirConversionTest {
     ObjectMapper objectMapper = new ObjectMapper();
     @Autowired
-    private CareCoalConverter careCoalConverter;
+    private CareGoalConverter careGoalConverter;
 
     @Test
     void getQdmType() {
-        assertEquals(CareCoalConverter.QDM_TYPE, careCoalConverter.getQdmType());
+        assertEquals(CareGoalConverter.QDM_TYPE, careGoalConverter.getQdmType());
     }
 
     @Test
@@ -51,7 +51,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
 
         qdmDataElement.setStatusDate(createStatusDate());
 
-        QdmToFhirConversionResult<Goal> result = careCoalConverter.convertToFhir(fhirPatient, qdmDataElement);
+        QdmToFhirConversionResult<Goal> result = careGoalConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
@@ -74,7 +74,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
         JsonNode node = objectMapper.valueToTree(targetOutcome);
         qdmDataElement.setTargetOutcome(node);
 
-        QdmToFhirConversionResult<Goal> result = careCoalConverter.convertToFhir(fhirPatient, qdmDataElement);
+        QdmToFhirConversionResult<Goal> result = careGoalConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
@@ -93,7 +93,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
 
         qdmDataElement.setTargetOutcome(node);
 
-        QdmToFhirConversionResult<Goal> result = careCoalConverter.convertToFhir(fhirPatient, qdmDataElement);
+        QdmToFhirConversionResult<Goal> result = careGoalConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
@@ -113,7 +113,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
         qdmDataElement.setDataElementCodes(List.of(createDataElementCode()));
         qdmDataElement.setTargetOutcome(node);
 
-        QdmToFhirConversionResult<Goal> result = careCoalConverter.convertToFhir(fhirPatient, qdmDataElement);
+        QdmToFhirConversionResult<Goal> result = careGoalConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
@@ -136,7 +136,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
         qdmDataElement.setDataElementCodes(List.of(createDataElementCode()));
         qdmDataElement.setTargetOutcome(node);
 
-        QdmToFhirConversionResult<Goal> result = careCoalConverter.convertToFhir(fhirPatient, qdmDataElement);
+        QdmToFhirConversionResult<Goal> result = careGoalConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
@@ -151,7 +151,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
         BooleanNode booleanNode = BooleanNode.FALSE; // fhir object Goal can take this we not handling this boolean type
         qdmDataElement.setTargetOutcome(booleanNode);
 
-        QdmToFhirConversionResult<Goal> result = careCoalConverter.convertToFhir(fhirPatient, qdmDataElement);
+        QdmToFhirConversionResult<Goal> result = careGoalConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
@@ -166,7 +166,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
         IntNode intNode = new IntNode(123);
         qdmDataElement.setTargetOutcome(intNode);
 
-        QdmToFhirConversionResult<Goal> result = careCoalConverter.convertToFhir(fhirPatient, qdmDataElement);
+        QdmToFhirConversionResult<Goal> result = careGoalConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
@@ -180,7 +180,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
         DoubleNode doubleNode = new DoubleNode(1.23);
         qdmDataElement.setTargetOutcome(doubleNode);
 
-        QdmToFhirConversionResult<Goal> result = careCoalConverter.convertToFhir(fhirPatient, qdmDataElement);
+        QdmToFhirConversionResult<Goal> result = careGoalConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
@@ -190,7 +190,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
 
     @Test
     void convertToFhirEmptyTargetOutcome() {
-        QdmToFhirConversionResult<Goal> result = careCoalConverter.convertToFhir(fhirPatient, qdmDataElement);
+        QdmToFhirConversionResult<Goal> result = careGoalConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
@@ -199,7 +199,7 @@ class CareCoalConverterTest extends BaseConversionTest implements FhirConversion
 
     @Test
     void convertToFhirEmptyObjects() {
-        QdmToFhirConversionResult<Goal> result = careCoalConverter.convertToFhir(fhirPatient, qdmDataElement);
+        QdmToFhirConversionResult<Goal> result = careGoalConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/CommunicationPerformedConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/CommunicationPerformedConverterTest.java
@@ -49,8 +49,8 @@ class CommunicationPerformedConverterTest extends BaseConversionTest implements 
         checkDataElementCodeableConcept(result.getFhirResource().getReasonCodeFirstRep());
 
         checkMedium(result.getFhirResource().getMediumFirstRep());
-        checkSentDatetime(result.getFhirResource().getSent());
-        checkReceivedDatetime(result.getFhirResource().getReceived());
+        checkSentDatetime(result.getFhirResource().getSentElement());
+        checkReceivedDatetime(result.getFhirResource().getReceivedElement());
         checkRelatedTo(result.getFhirResource().getBasedOnFirstRep());
         checkSender(result.getFhirResource().getSender());
         checkRecipient(result.getFhirResource().getRecipientFirstRep());

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/DiagnosisConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/DiagnosisConverterTest.java
@@ -38,18 +38,16 @@ class DiagnosisConverterTest extends BaseConversionTest implements FhirConversio
 
         assertEquals(0, result.getConversionMessages().size());
         checkSeverity(result.getFhirResource().getSeverity());
-        checkAuthorDatetime(result.getFhirResource().getRecordedDate());
+        checkAuthorDatetime(result.getFhirResource().getRecordedDateElement());
 
         QdmPeriod qdmPeriod = createPrevalencePeriod();
-        assertEquals(qdmPeriod.getLow(), result.getFhirResource().getOnsetDateTimeType().getValue());
-        assertEquals(qdmPeriod.getHigh(), result.getFhirResource().getAbatementDateTimeType().getValue());
+        assertEquals(qdmPeriod.getLow(), result.getFhirResource().getOnsetDateTimeType());
+        assertEquals(qdmPeriod.getHigh(), result.getFhirResource().getAbatementDateTimeType());
 
         checkAnatomicalLocationSite(result.getFhirResource().getBodySiteFirstRep());
 
         assertEquals("Active", result.getFhirResource().getClinicalStatus().getCoding().get(0).getDisplay());
         assertEquals("Confirmed", result.getFhirResource().getVerificationStatus().getCoding().get(0).getDisplay());
-
-
     }
 
     @Test

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/DiagnosticStudyPerformedConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/DiagnosticStudyPerformedConverterTest.java
@@ -53,7 +53,7 @@ class DiagnosticStudyPerformedConverterTest extends BaseConversionTest implement
         QdmToFhirConversionResult<Observation> result =
                 diagnosticStudyPerformedConverter.convertToFhir(fhirPatient, qdmDataElement);
 
-        checkRelevantDateTime(result.getFhirResource().getEffectiveDateTimeType().getValue());
+        checkRelevantDateTime(result.getFhirResource().getEffectiveDateTimeType());
     }
 
 

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/FamilyHistoryConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/FamilyHistoryConverterTest.java
@@ -39,7 +39,7 @@ class FamilyHistoryConverterTest extends BaseConversionTest implements FhirConve
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getPatient());
 
         checkDataElementCodeableConcept(result.getFhirResource().getConditionFirstRep().getCode());
-        checkAuthorDatetime(result.getFhirResource().getDate());
+        checkAuthorDatetime(result.getFhirResource().getDateElement());
         checkRelationShip(result.getFhirResource().getRelationship());
 
         assertEquals(FamilyMemberHistory.FamilyHistoryStatus.COMPLETED, result.getFhirResource().getStatus());

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/ImmunizationAdministeredConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/ImmunizationAdministeredConverterTest.java
@@ -41,7 +41,7 @@ class ImmunizationAdministeredConverterTest extends BaseConversionTest implement
         checkDataElementCodeableConcept(result.getFhirResource().getVaccineCode());
         checkDosage(result.getFhirResource().getDoseQuantity());
         checkRoute(result.getFhirResource().getRoute());
-        checkRelevantDateTime(result.getFhirResource().getOccurrenceDateTimeType().getValue());
+        checkRelevantDateTime(result.getFhirResource().getOccurrenceDateTimeType());
         checkPerformer(result.getFhirResource().getPerformerFirstRep().getActor());
 
         assertEquals(Immunization.ImmunizationStatus.COMPLETED, result.getFhirResource().getStatus());

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/MedicationAdministeredConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/MedicationAdministeredConverterTest.java
@@ -67,7 +67,7 @@ class MedicationAdministeredConverterTest extends BaseConversionTest implements 
         QdmToFhirConversionResult<MedicationAdministration> result =
                 medicationAdministeredConverter.convertToFhir(fhirPatient, qdmDataElement);
         assertNotNull(result);
-        checkRelevantDateTime(result.getFhirResource().getEffectiveDateTimeType().getValue());
+        checkRelevantDateTime(result.getFhirResource().getEffectiveDateTimeType());
     }
 
     @Test

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/MedicationDispensedConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/MedicationDispensedConverterTest.java
@@ -49,7 +49,7 @@ class MedicationDispensedConverterTest extends BaseConversionTest implements Fhi
         checkSupply(result.getFhirResource().getQuantity());
         checkDaysSupply(result.getFhirResource().getDaysSupply());
         checkFrequency(result.getFhirResource().getDosageInstructionFirstRep().getTiming().getCode());
-        checkRelevantDateTime(result.getFhirResource().getWhenHandedOver());
+        checkRelevantDateTime(result.getFhirResource().getWhenHandedOverElement());
         checkRelevantPeriod(result.getFhirResource().getDosageInstructionFirstRep().getTiming().getRepeat().getBoundsPeriod());
         checkPrescriber(result.getFhirResource().getAuthorizingPrescriptionFirstRep());
         checkDispenser(result.getFhirResource().getPerformerFirstRep().getActor());

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/PatientConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/PatientConverterTest.java
@@ -11,6 +11,7 @@ import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmPatient;
 import lombok.SneakyThrows;
 import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Extension;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +21,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Set;
 
 import static gov.cms.mat.patients.conversion.conversion.PatientConverter.DETAILED_RACE_URL;
@@ -111,10 +111,10 @@ class PatientConverterTest implements ResourceFileUtil, FhirCreator, DataElement
 
     @Test
     void convertExpired() {
-        Date deathDate = new Date();
+        var now = DateTimeType.now();
 
         var expiredElement = create("QDM::PatientCharacteristicExpired");
-        expiredElement.setExpiredDatetime(deathDate);
+        expiredElement.setExpiredDatetime(now);
         bonniePatient.getQdmPatient().getDataElements().add(expiredElement);
 
         QdmToFhirPatientResult result = patientConverter.convert(bonniePatient, collectQdmTypes(bonniePatient));
@@ -123,7 +123,7 @@ class PatientConverterTest implements ResourceFileUtil, FhirCreator, DataElement
         assertEquals(0, result.getOutcome().getValidationMessages().size());
 
         assertTrue(result.getFhirPatient().hasDeceased()); // Im dead
-        assertEquals(deathDate, result.getFhirPatient().getDeceasedDateTimeType().getValue());
+        assertEquals(now, result.getFhirPatient().getDeceasedDateTimeType());
     }
 
     @Test

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/SubstanceAdministeredConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/SubstanceAdministeredConverterTest.java
@@ -44,7 +44,7 @@ class SubstanceAdministeredConverterTest extends BaseConversionTest implements F
         // DataElementCodes mapped twice
         checkDataElementCodeableConcept(result.getFhirResource().getOralDiet().getTypeFirstRep());
 
-        checkAuthorDatetime(result.getFhirResource().getDateTime());
+        checkAuthorDatetime(result.getFhirResource().getDateTimeElement());
 
         // DataElementCodes mapped twice
         checkDataElementCodeableConcept(result.getFhirResource().getEnteralFormula().getBaseFormulaType());
@@ -59,7 +59,7 @@ class SubstanceAdministeredConverterTest extends BaseConversionTest implements F
     }
 
     private void checkRelevantPeriodTiming(Timing schedule) {
-        assertEquals(createRelevantPeriod().getLow(), schedule.getEvent().get(0).getValue());
+        assertEquals(createRelevantPeriod().getLow(), schedule.getEvent().get(0));
     }
 
     @Test

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/SymptomConverterTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/SymptomConverterTest.java
@@ -4,6 +4,7 @@ import gov.cms.mat.patients.conversion.conversion.helpers.BaseConversionTest;
 import gov.cms.mat.patients.conversion.conversion.helpers.FhirConversionTest;
 import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionResult;
 import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Period;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,7 +38,7 @@ class SymptomConverterTest extends BaseConversionTest implements FhirConversionT
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
 
         checkDataElementCodeableConcept(result.getFhirResource().getValueCodeableConcept());
-        checkPrevalencePeriod(result.getFhirResource().getEffectivePeriod());
+        checkPrevalencePeriod((Period) result.getFhirResource().getEffective());
         checkSeverity(result.getFhirResource().getInterpretationFirstRep());
     }
 

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/FhirConversionTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/FhirConversionTest.java
@@ -18,23 +18,7 @@ import gov.cms.mat.patients.conversion.dao.conversion.QdmPeriod;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmPractitioner;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmQuantity;
 import gov.cms.mat.patients.conversion.dao.conversion.TargetOutcome;
-import org.hl7.fhir.r4.model.BooleanType;
-import org.hl7.fhir.r4.model.CodeableConcept;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.DateTimeType;
-import org.hl7.fhir.r4.model.DateType;
-import org.hl7.fhir.r4.model.Duration;
-import org.hl7.fhir.r4.model.Extension;
-import org.hl7.fhir.r4.model.HumanName;
-import org.hl7.fhir.r4.model.Identifier;
-import org.hl7.fhir.r4.model.IntegerType;
-import org.hl7.fhir.r4.model.Observation;
-import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Period;
-import org.hl7.fhir.r4.model.Quantity;
-import org.hl7.fhir.r4.model.Reference;
-import org.hl7.fhir.r4.model.StringType;
-import org.hl7.fhir.r4.model.Type;
+import org.hl7.fhir.r4.model.*;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -58,7 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public interface FhirConversionTest {
-    Instant now = Instant.now();
+    long currentTime = System.currentTimeMillis();
+    DateTimeType dateTimeTypeNow = DateTimeType.now();
 
     default void checkSNOMEDCodeableConcept(CodeableConcept codeableConcept, String code, String display) {
         assertEquals(1, codeableConcept.getCoding().size());
@@ -127,55 +112,55 @@ public interface FhirConversionTest {
     }
 
 
-    default Date createRelevantDatetime() {
-        return new Date(now.toEpochMilli() - 10000);
+    default DateTimeType createRelevantDatetime() {
+        return dateTimeTypeNow;
     }
 
-    default void checkRelevantDateTime(Date relevantDatetime) {
+    default void checkRelevantDateTime(DateTimeType relevantDatetime) {
         assertEquals(createRelevantDatetime(), relevantDatetime);
     }
 
     default QdmPeriod createPrevalencePeriod() {
         QdmPeriod qdmPeriod = new QdmPeriod();
-        qdmPeriod.setLow(new Date(now.toEpochMilli() - 1000000));
-        qdmPeriod.setHigh(new Date(now.toEpochMilli() - 100));
+        qdmPeriod.setLow(dateTimeTypeNow);
+        qdmPeriod.setHigh(dateTimeTypeNow);
         return qdmPeriod;
     }
 
     default void checkPrevalencePeriod(Period fhirPeriod) {
         QdmPeriod qdmPeriod = createPrevalencePeriod();
 
-        assertEquals(qdmPeriod.getLow(), fhirPeriod.getStart());
-        assertEquals(qdmPeriod.getHigh(), fhirPeriod.getEnd());
+        assertEquals(qdmPeriod.getLow(), fhirPeriod.getStartElement());
+        assertEquals(qdmPeriod.getHigh(), fhirPeriod.getEndElement());
     }
 
     default QdmPeriod createParticipationPeriod() {
         QdmPeriod qdmPeriod = new QdmPeriod();
-        qdmPeriod.setLow(new Date(now.toEpochMilli() - 1000000));
-        qdmPeriod.setHigh(new Date(now.toEpochMilli() - 100));
+        qdmPeriod.setLow(dateTimeTypeNow);
+        qdmPeriod.setHigh(dateTimeTypeNow);
         return qdmPeriod;
     }
 
     default void checkParticipationPeriod(Period fhirPeriod) {
         QdmPeriod qdmPeriod = createPrevalencePeriod();
 
-        assertEquals(qdmPeriod.getLow(), fhirPeriod.getStart());
-        assertEquals(qdmPeriod.getHigh(), fhirPeriod.getEnd());
+        assertEquals(qdmPeriod.getLow(), fhirPeriod.getStartElement());
+        assertEquals(qdmPeriod.getHigh(), fhirPeriod.getEndElement());
     }
 
-    default Date createAuthorDatetime() {
-        return new Date(now.toEpochMilli() - 50);
+    default DateTimeType createAuthorDatetime() {
+        return dateTimeTypeNow;
     }
 
     default Date createActiveDatetime() {
-        return new Date(now.toEpochMilli() - 7777);
+        return new Date(currentTime - 7777);
     }
 
     default void checkActiveDatetime(Date date) {
         assertEquals(createActiveDatetime(), date);
     }
 
-    default void checkAuthorDatetime(Date date) {
+    default void checkAuthorDatetime(DateTimeType date) {
         assertEquals(createAuthorDatetime(), date);
     }
 
@@ -264,24 +249,22 @@ public interface FhirConversionTest {
 
     default QdmPeriod createRelevantPeriod() {
         QdmPeriod qdmPeriod = new QdmPeriod();
-        qdmPeriod.setLow(new Date(now.toEpochMilli() - 2000000));
-        qdmPeriod.setHigh(new Date(now.toEpochMilli() - 1000));
+        qdmPeriod.setLow(dateTimeTypeNow);
+        qdmPeriod.setHigh(dateTimeTypeNow);
         return qdmPeriod;
     }
 
     default void checkRelevantPeriod(Period fhirPeriod) {
         QdmPeriod qdmPeriod = createRelevantPeriod();
 
-        assertEquals(qdmPeriod.getLow(), fhirPeriod.getStart());
-        assertEquals(qdmPeriod.getHigh(), fhirPeriod.getEnd());
+        assertEquals(qdmPeriod.getLow(), fhirPeriod.getStartElement());
+        assertEquals(qdmPeriod.getHigh(), fhirPeriod.getEndElement());
     }
 
-    default void checkRelevantPeriodGoal(Type start, DateType end) {
+    default void checkRelevantPeriodGoal(DateType start, DateType end) {
         assertThat(start, instanceOf(DateType.class));
-        DateType dateType = (DateType) start;
-        assertEquals(new Date(now.toEpochMilli() - 2000000), dateType.getValue());
-
-        assertEquals(new Date(now.toEpochMilli() - 1000), end.getValue());
+        assertEquals(dateTimeTypeNow, start);
+        assertEquals(dateTimeTypeNow, end);
     }
 
     default QdmComponent createComponents() {
@@ -298,8 +281,8 @@ public interface FhirConversionTest {
 
 
         QdmPeriod qdmPeriod = new QdmPeriod();
-        qdmPeriod.setLow(new Date(now.toEpochMilli() - 20000));
-        qdmPeriod.setHigh(new Date(now.toEpochMilli() - 999));
+        qdmPeriod.setLow(new DateTimeType(new Date(System.currentTimeMillis() - 10000)));
+        qdmPeriod.setHigh(new DateTimeType(new Date(System.currentTimeMillis() - 999)));
 
         qdmComponent.setReferenceRange(qdmPeriod);
 
@@ -464,19 +447,19 @@ public interface FhirConversionTest {
         checkSNOMEDCodeableConcept(codeableConcept, "408563008", "Email sent to consultant (finding)");
     }
 
-    default Date createSentDatetime() {
-        return new Date(now.toEpochMilli() - 12345);
+    default DateTimeType createSentDatetime() {
+        return dateTimeTypeNow;
     }
 
-    default void checkSentDatetime(Date sent) {
+    default void checkSentDatetime(DateTimeType sent) {
         assertEquals(createSentDatetime(), sent);
     }
 
-    default Date createReceivedDatetime() {
-        return new Date(now.toEpochMilli() - 1);
+    default DateTimeType createReceivedDatetime() {
+        return dateTimeTypeNow;
     }
 
-    default void checkReceivedDatetime(Date received) {
+    default void checkReceivedDatetime(DateTimeType received) {
         assertEquals(createReceivedDatetime(), received);
     }
 
@@ -493,7 +476,7 @@ public interface FhirConversionTest {
         assertThat(extension.getValue(), instanceOf(DateTimeType.class));
         DateTimeType dateTimeType = (DateTimeType) extension.getValue();
 
-        assertEquals(createAuthorDatetime(), dateTimeType.getValue());
+        assertEquals(createAuthorDatetime(), dateTimeType);
 
         assertEquals(QICORE_RECORDED, extension.getUrl());
     }
@@ -570,11 +553,11 @@ public interface FhirConversionTest {
         assertEquals(NO_STATUS_MAPPING, conversionMessages.get(0));
     }
 
-    default Date createIncisionDatetime() {
-        return new Date(now.toEpochMilli() - 2222);
+    default DateTimeType createIncisionDatetime() {
+        return dateTimeTypeNow;
     }
 
-    default void checkIncisionDatetime(Date date) {
+    default void checkIncisionDatetime(DateTimeType date) {
         assertEquals(createIncisionDatetime(), date);
     }
 
@@ -606,7 +589,7 @@ public interface FhirConversionTest {
     }
 
     default Date createStatusDate() {
-        return new Date(now.toEpochMilli() - 9994);
+        return new Date(currentTime - 9994);
     }
 
     default void checkStatusDate(Date statusDate) {

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/FhirConversionTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/FhirConversionTest.java
@@ -20,7 +20,6 @@ import gov.cms.mat.patients.conversion.dao.conversion.QdmQuantity;
 import gov.cms.mat.patients.conversion.dao.conversion.TargetOutcome;
 import org.hl7.fhir.r4.model.*;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -43,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public interface FhirConversionTest {
     long currentTime = System.currentTimeMillis();
-    DateTimeType dateTimeTypeNow = DateTimeType.now();
+    DateTimeType now = DateTimeType.now();
 
     default void checkSNOMEDCodeableConcept(CodeableConcept codeableConcept, String code, String display) {
         assertEquals(1, codeableConcept.getCoding().size());
@@ -113,7 +112,7 @@ public interface FhirConversionTest {
 
 
     default DateTimeType createRelevantDatetime() {
-        return dateTimeTypeNow;
+        return now;
     }
 
     default void checkRelevantDateTime(DateTimeType relevantDatetime) {
@@ -122,8 +121,8 @@ public interface FhirConversionTest {
 
     default QdmPeriod createPrevalencePeriod() {
         QdmPeriod qdmPeriod = new QdmPeriod();
-        qdmPeriod.setLow(dateTimeTypeNow);
-        qdmPeriod.setHigh(dateTimeTypeNow);
+        qdmPeriod.setLow(now);
+        qdmPeriod.setHigh(now);
         return qdmPeriod;
     }
 
@@ -136,8 +135,8 @@ public interface FhirConversionTest {
 
     default QdmPeriod createParticipationPeriod() {
         QdmPeriod qdmPeriod = new QdmPeriod();
-        qdmPeriod.setLow(dateTimeTypeNow);
-        qdmPeriod.setHigh(dateTimeTypeNow);
+        qdmPeriod.setLow(now);
+        qdmPeriod.setHigh(now);
         return qdmPeriod;
     }
 
@@ -149,7 +148,7 @@ public interface FhirConversionTest {
     }
 
     default DateTimeType createAuthorDatetime() {
-        return dateTimeTypeNow;
+        return now;
     }
 
     default Date createActiveDatetime() {
@@ -249,8 +248,8 @@ public interface FhirConversionTest {
 
     default QdmPeriod createRelevantPeriod() {
         QdmPeriod qdmPeriod = new QdmPeriod();
-        qdmPeriod.setLow(dateTimeTypeNow);
-        qdmPeriod.setHigh(dateTimeTypeNow);
+        qdmPeriod.setLow(now);
+        qdmPeriod.setHigh(now);
         return qdmPeriod;
     }
 
@@ -261,10 +260,9 @@ public interface FhirConversionTest {
         assertEquals(qdmPeriod.getHigh(), fhirPeriod.getEndElement());
     }
 
-    default void checkRelevantPeriodGoal(DateType start, DateType end) {
-        assertThat(start, instanceOf(DateType.class));
-        assertEquals(dateTimeTypeNow, start);
-        assertEquals(dateTimeTypeNow, end);
+    default void checkRelevantPeriodGoal(DateType start, DateType due) {
+        assertEquals(now, start);
+        assertEquals(now, due);
     }
 
     default QdmComponent createComponents() {
@@ -448,7 +446,7 @@ public interface FhirConversionTest {
     }
 
     default DateTimeType createSentDatetime() {
-        return dateTimeTypeNow;
+        return now;
     }
 
     default void checkSentDatetime(DateTimeType sent) {
@@ -456,7 +454,7 @@ public interface FhirConversionTest {
     }
 
     default DateTimeType createReceivedDatetime() {
-        return dateTimeTypeNow;
+        return now;
     }
 
     default void checkReceivedDatetime(DateTimeType received) {
@@ -554,7 +552,7 @@ public interface FhirConversionTest {
     }
 
     default DateTimeType createIncisionDatetime() {
-        return dateTimeTypeNow;
+        return now;
     }
 
     default void checkIncisionDatetime(DateTimeType date) {

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/MedicationRequestTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/MedicationRequestTest.java
@@ -60,9 +60,9 @@ public interface MedicationRequestTest extends FhirConversionTest {
 
         checkReason(result.getFhirResource().getReasonCode().get(0));
 
-        checkRelevantDateTime(result.getFhirResource().getDosageInstructionFirstRep().getTiming().getEvent().get(0).getValue());
+        checkRelevantDateTime(result.getFhirResource().getDosageInstructionFirstRep().getTiming().getEvent().get(0));
         checkRelevantPeriod(result.getFhirResource().getDosageInstructionFirstRep().getTiming().getRepeat().getBoundsPeriod());
-        checkAuthorDatetime(result.getFhirResource().getAuthoredOn());
+        checkAuthorDatetime(result.getFhirResource().getAuthoredOnElement());
 
         //  checkActiveDatetimePeriod(result.getFhirResource().getDosageInstructionFirstRep().getTiming().getRepeat().getBoundsPeriod());
     }

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/ObservationCommonTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/ObservationCommonTest.java
@@ -4,9 +4,7 @@ import gov.cms.mat.patients.conversion.conversion.results.QdmToFhirConversionRes
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmQuantity;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmReferenceRange;
-import org.hl7.fhir.r4.model.BooleanType;
-import org.hl7.fhir.r4.model.Extension;
-import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.*;
 
 import java.util.List;
 
@@ -22,10 +20,9 @@ public interface ObservationCommonTest extends FhirConversionTest {
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
         checkDataElementCodeableConcept(result.getFhirResource().getCode());
 
-        checkAuthorDatetime(result.getFhirResource().getIssued());
         checkComponents(result.getFhirResource().getComponent());
 
-        checkRelevantPeriod(result.getFhirResource().getEffectivePeriod());
+        checkRelevantPeriod((Period) result.getFhirResource().getEffective());
 
         checkMethod(result.getFhirResource().getMethod());
 

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/ProcedureConversionTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/ProcedureConversionTest.java
@@ -9,7 +9,6 @@ import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Procedure;
 
-import java.util.Date;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -78,8 +77,6 @@ public interface ProcedureConversionTest extends FhirConversionTest {
 
         assertThat(extension.getValue(), instanceOf(DateTimeType.class));
 
-        DateTimeType dateTimeType = (DateTimeType) extension.getValue();
-
-        return dateTimeType;
+        return (DateTimeType) extension.getValue();
     }
 }

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/ProcedureConversionTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/ProcedureConversionTest.java
@@ -6,6 +6,7 @@ import gov.cms.mat.patients.conversion.dao.conversion.QdmCodeSystem;
 import gov.cms.mat.patients.conversion.dao.conversion.QdmDataElement;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Procedure;
 
 import java.util.Date;
@@ -65,13 +66,13 @@ public interface ProcedureConversionTest extends FhirConversionTest {
 
         assertEquals("Cannot convert QDM attribute result", result.getConversionMessages().get(2));
 
-        checkRelevantPeriod(result.getFhirResource().getPerformedPeriod());
+        checkRelevantPeriod((Period) result.getFhirResource().getPerformed());
         checkIncisionDatetime(checkIncision(result.getFhirResource().getExtension()));
 
         checkAnatomicalLocationSite(result.getFhirResource().getBodySiteFirstRep());
     }
 
-    default Date checkIncision(List<Extension> extensions) {
+    default DateTimeType checkIncision(List<Extension> extensions) {
         assertEquals(2, extensions.size());
         Extension extension = extensions.get(0);
 
@@ -79,6 +80,6 @@ public interface ProcedureConversionTest extends FhirConversionTest {
 
         DateTimeType dateTimeType = (DateTimeType) extension.getValue();
 
-        return dateTimeType.getValue();
+        return dateTimeType;
     }
 }

--- a/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/ServiceRequestCommonTest.java
+++ b/src/test/java/gov/cms/mat/patients/conversion/conversion/helpers/ServiceRequestCommonTest.java
@@ -15,7 +15,7 @@ public interface ServiceRequestCommonTest extends FhirConversionTest {
     default void checkDataElement(QdmToFhirConversionResult<ServiceRequest> result) {
         checkBase(result.getFhirResource().getId(), result.getFhirResource().getSubject());
         checkDataElementCodeableConcept(result.getFhirResource().getCode());
-        checkAuthorDatetime(result.getFhirResource().getAuthoredOn());
+        checkAuthorDatetime(result.getFhirResource().getAuthoredOnElement());
         checkReason(result.getFhirResource().getReasonCodeFirstRep());
     }
 


### PR DESCRIPTION
[MAT-3267](https://jira.cms.gov/browse/MAT-3267)

Changes to accept milliseconds from QDM patient data elements DateTime attributes and persisting them in FHIR patients.
Millisecond's field is optional in QDM patients, if not present then defaulted to '000', if the present value is persisted.
Seconds are mandatory. if not present 404 bad request is thrown.

Since the existing use of Java. util.Date doesn't persist milliSeconds, we are using org.hl7.fhir.r4.model.DateTimeType instead
the Precision of DateTimeType attributes is set to Millis.

Example QDM attribute
     "authorDatetime": "2012-10-29T08:00:00.234Z",
234 milliseconds are present, then the FHIR equivalent also persists it.
FHIR equivalent -> "authoredOn": "2012-10-29T08:00:00.234Z",

List of Attributes for various dataElements that require to accept milliSeconds and copy them over to FHIR patient if available.

- participationPeriod.low
- participationPeriod.high
- expiredDatetime
- activeDatetime
- birthDatetime
- authorDatetime
- relevantPeriod.low
- relevantPeriod.high
- prevalencePeriod.low
- prevalencePeriod.high
- resultDatetime
- incisionDatetime
- relevantDatetime
- sentDatetime
- receivedDatetime

These attributes don't need to change
- statusDate (accepts only date)
- birthDatetime (not a part of DataElement)

All tests cases are altered to work with new changes in DataType for DateTime attributes. 
Test cases were run locally and passed.

Regarding QDM::CareGoal http://hl7.org/fhir/us/qicore/qdm-to-qicore.html#86-care-goal

FHIR::Goal is currently not implemented in Bonnie.

QDM relevantPeriod.low is mapped to FHIR Goal.start[x]
QDM relevantPeriod.high is mapped to FHIR Goal.target.due[x]
relevantPeriod.low & High both can accept time as a field, but the document specifies that the FHIR equivalent is of type Date, so in that case, the time has to be dropped unless Bonnie's implementation of CareGoal already takes care of it.

During conversion, if we need to drop the Time, do we have to consider TimeZone ? or UTC is assumed by default? --> Question to SMEs 
Commented out code and added comments to track the fix. Reported to Nicole about CareGoal being not implemented. 
